### PR TITLE
Added command line option help emitting basic message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG for `yak`
 
-# 0.3.0 Milestone release, implementing about command line option
+# 0.4.0 Milestone release, implementing help command line option
+
+- Added command line arguments `--help` and it emits:
+    - listing of all command line options with short description
+
+# 0.3.0 Milestone release, implementing abou
+
+t command line option
 
 - Added command line arguments `--about` and it emits:
 - current version number of `yak`
@@ -20,8 +27,8 @@ CHANGELOG for `yak`
 # 0.1.0 Milestone release, implementing initial features
 
 - Can be configured using file and configuration supports:
-  - `verbosity` tells `yak` to emit more verbose output 
-  - `debug` tells `yak` to emit debug output 
+  - `verbosity` tells `yak` to emit more verbose output
+  - `debug` tells `yak` to emit debug output
   - the configuration file is in YAML and has to be placed in: `$HOME/.config/yak/config.yml`
 - Can take command line arguments, currently supported is
   - `--verbose` overwrites config and tells `yak` to emit more verbose output

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ This JSON file should be created as `$HOME/.config/yak/checksums.json`.
 - `--nodebug`, disables debug output even if confgured or provided as `--debug`, see above
 - `--noconfig`, disables reading of the configuration file, (see ["CONFIGURATION"](#configuration)) and you have to rely on the command line arguments
 - `--nochecksums`, disables reading of the global checksums file (see ["DATA\_SOURCE"](#data_source))
-- `--about`, emits output on configuration and invocation and terminates with success.
+- `--about`, emits output on configuration and invocation and terminates with success
+- `--help`, emits help message listing all available options
 
 Command line arguments override the configuration.
 

--- a/yak
+++ b/yak
@@ -274,7 +274,9 @@ C<yak> takes the following command line arguments:
 
 =item * C<--nochecksums>, disables reading of the global checksums file (see L</DATA_SOURCE>)
 
-=item * C<--about>, emits output on configuration and invocation and terminates with success.
+=item * C<--about>, emits output on configuration and invocation and terminates with success
+
+=item * C<--help>, emits help message listing all available options
 
 =back
 

--- a/yak
+++ b/yak
@@ -28,6 +28,7 @@ my $silent_flag      = FALSE;
 my $noconfig_flag    = FALSE;
 my $nochecksums_flag = FALSE;
 my $about_flag       = FALSE;
+my $help_flag        = FALSE;
 my $rv               = SUCCESS;
 my $checksums_src    = "$HOME/.config/yak/checksums.json";
 my $config_file      = "$HOME/.config/yak/config.yml";
@@ -39,6 +40,7 @@ GetOptions ('debug'       => \$debug_flag,
             'silent'      => \$silent_flag,
             'nochecksums' => \$nochecksums_flag,
             'about'       => \$about_flag,
+            'help'        => \$help_flag,
 ) or die "Error in command line arguments\n";
 
 # Reading the config
@@ -65,7 +67,7 @@ close $checksums_fh;
 my $checksums = from_json($checksum_json);
 
 if ($about_flag) {
-    print "$PROGRAM_NAME : $VERSION\n";
+    print "$PROGRAM_NAME version $VERSION\n";
     print "\n";
     if (not $noconfig_flag) {
         print "Using configuration located at: $config_file\n" ;
@@ -83,6 +85,25 @@ if ($about_flag) {
     print "--silent\n"      if $silent_flag;
     print "--nochecksums\n" if $nochecksums_flag;
     print "--about\n"       if $about_flag;
+    print "\n";
+
+    exit $rv;
+}
+
+if ($help_flag) {
+    print "$PROGRAM_NAME version $VERSION\n";
+    print "\n";
+    print "$PROGRAM_NAME [options]\n";
+    print "\n";
+    print "Options\n";
+    print "\n";
+    print "--debug: debug output\n";
+    print "--nodebug: disabling debug output, if configured\n";
+    print "--verbose: more verbose output\n";
+    print "--noconfig: ignore \$HOME/.config/.yak/config.yml\n";
+    print "--silent: suppress all output and rely on return value\n";
+    print "--nochecksums: ignore \$HOME/.config/.yak/checksums.json and use local .yaksums\n";
+    print "--about: emit configuration and invocation description\n";
     print "\n";
 
     exit $rv;
@@ -153,7 +174,7 @@ sub _set_debug {
 sub _is_debug_config_true {
     my $config = shift;
 
-    if ($config) {
+    if ($config and $config->[0]->{debug}) {
         return $config->[0]->{debug} eq 'true'?TRUE:FALSE;
     } else {
         return FALSE;
@@ -163,7 +184,7 @@ sub _is_debug_config_true {
 sub _is_verbosity_config_true {
     my $config = shift;
 
-    if ($config) {
+    if ($config and $config->[0]->{verbose}) {
         return $config->[0]->{verbose} eq 'true'?TRUE:FALSE;
     } else {
         return FALSE;


### PR DESCRIPTION
This closes issue #12 with first implementation of `--help` command line flag emitting basic listing of all command line options with brief description and versionnumber of yak