### PR TITLE
Added support for suppressing colorized output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG for `yak`
 
+## 0.7.0 2020-11-21 Milestone release, implementing color and nocolor control
+
+- Added configuration option `color`
+  - can be configured in: `$HOME/.config/yak/config.yaml`
+  - can be used to override default value of enabled
+
+- Added command line argument `--color`
+  - can be used to override `color` configuration specified in: `$HOME/.config/yak/config.yaml`
+
+- Added command line argument `--nocolor`
+  - overriding default value of enabled
+  - can be used to override `color` configuration specified in: `$HOME/.config/yak/config.yaml`
+  - overriding`--color` command line argument
+
 ## 0.6.0 2020-11-21 Milestone release, implementing checksums command line option
 
 - Added command line argument `--config <data source file>`

--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ This JSON file should be created as `$HOME/.config/yak/checksums.json`.
 - `--nodebug`, disables debug output even if confgured or provided as `--debug`, see above
 - `--config file`, reads alternative configuration file instead of default, see ["CONFIGURATION"](#configuration)
 - `--noconfig`, disables reading of the configuration file, (see ["CONFIGURATION"](#configuration)) and you have to rely on the command line arguments
-- `--nochecksums`, disables reading of the global checksums file (see ["DATA\_SOURCE"](#data_source))
+- `--nochecksums`, disables reading of the global checksums file, see ["DATA\_SOURCE"](#data_source)
+- `--checksums file`, reads alternative checksums file instead of default, see ["DATA\_SOURCE"](#data_source)
+- `--color`, enables colorized output, enabled by default or can be configured, see ["CONFIGURATION"](#configuration)
+- `--nocolor`, disables colorized output, even if confgured or provided as `--color`, see above
 - `--about`, emits output on configuration and invocation and terminates with success
 - `--help`, emits help message listing all available options
 
@@ -79,8 +82,9 @@ Note that `--about` return as success with out processing any data apart from re
 
 `yak` can be configured using the following paramters:
 
-- `verbose`, which enables more verbose output
-- `debug`, which enables debug output
+- `verbose`, enabling (`true`) or disabling (`false`) more verbose output
+- `debug`, enabling (`true`) or disabling (`false`) debug output
+- `color`, enabling (`true`) or disabling (`false`) colorized output
 
 Configuration can be overridden by command line arguments, see ["INVOCATION"](#invocation).
 
@@ -92,6 +96,12 @@ This YAML file should be created as `$HOME/.config/yak/config.yml`.
     debug: false
 
 # DATA SOURCE
+
+There are 3 ways to provide checksum data to `yak`.
+
+- The default using: `$HOME/.config/yak/checksums.json`, which can then be edited to match your needs
+- Using a project or repository specific: `.yaksums.json` located in the root of your project or repository directory
+- Using an JSON file adhering to formatting described in this chapter, which can be located elsewhere on your file system
 
 The default data source is described in the ["DESCRIPTION"](#description). As a an alternative a per project file can be specified in the designated repository/directory.
 
@@ -133,7 +143,7 @@ The Docker image has the following command line arguments embedded:
 - `--noconfig`
 - `--nochecksums`
 
-Since the ability to read files outside the Docker container is limited to the directory mounted.
+Since the ability to read files outside the Docker container is limited to mounted directories.
 
 The mount point is expected to be a directory containing the files to be checked against the checksum data structure. Please see the ["LIMITATIONS"](#limitations) for details.
 
@@ -166,14 +176,22 @@ Used commonly for repetive and boring work, required to reach a certain goal.
 
 # AUTHOR
 
-- jonasbn <jonasbn@cpan.org>
+- jonasbn, [website](https://jonasbn.github.io/)
 
 # COPYRIGHT
 
-`yak` is (C) by Jonas B. Nielsen, (jonasbn) 2018-2020
+`yak` is (C) by Jonas Brømsø, (jonasbn) 2018-2020
 
 Image used on the `yak` [website](https://jonasbn.github.io/yak/) is under copyright by [Shane Aldendorff](https://unsplash.com/photos/3b3O75X0Jzg)
 
 # LICENSE
 
 `yak` is released under the MIT License
+
+# POD ERRORS
+
+Hey! **The above document had some coding errors, which are explained below:**
+
+- Around line 526:
+
+    Non-ASCII character seen before =encoding in 'Brømsø,'. Assuming UTF-8

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -2,3 +2,4 @@ ignore_dirs:
 - .git
 - local
 verbose: false
+color: false

--- a/t/test.t
+++ b/t/test.t
@@ -19,6 +19,8 @@ if ($CONTINUOUS_INTEGRATION and $CONTINUOUS_INTEGRATION eq 'true') {
     script_runs(['yak', '--silent'], '"yak --silent" runs');
     script_runs(['yak', '--nochecksums'], '"yak --nochecksums" runs');
     script_runs(['yak', '--checksums', 'examples/checksums.json'], '"yak --checksums examples/checksums.json" runs');
+    script_runs(['yak', '--color'], '"yak --color" runs');
+    script_runs(['yak', '--nocolor'], '"yak --nocolor" runs');
 }
 
 done_testing;

--- a/yak
+++ b/yak
@@ -32,6 +32,8 @@ my $noconfig_flag    = FALSE;
 my $nochecksums_flag = FALSE;
 my $about_flag       = FALSE;
 my $help_flag        = FALSE;
+my $nocolor_flag     = FALSE;
+my $color_flag       = FALSE;
 my $rv               = SUCCESS;
 my $checksums_src    = '';
 my $config_file      = '';
@@ -44,6 +46,8 @@ GetOptions ('debug'       => \$debug_flag,
             'silent'      => \$silent_flag,
             'nochecksums' => \$nochecksums_flag,
             'checksums=s' => \$checksums_src,
+            'nocolor'     => \$nocolor_flag,
+            'color'       => \$color_flag,
             'about'       => \$about_flag,
             'help'        => \$help_flag,
 ) or die "Error in command line arguments\n";
@@ -60,8 +64,9 @@ if ($noconfig_flag) {
     }
 }
 
-my $verbose = _set_verbose($verbosity_flag, $silent_flag, $config) || 0;
-my $debug = _set_debug($debug_flag, $nodebug_flag, $config) || 0;
+my $verbose = _set_verbose($verbosity_flag, $silent_flag, $config);
+my $debug = _set_debug($debug_flag, $nodebug_flag, $config);
+my $color = _set_color($color_flag, $nocolor_flag, $config);
 
 # Reading the checksum data
 my $checksums_file = '';
@@ -75,7 +80,6 @@ if ($nochecksums_flag) {
     } else {
         $checksums_file = $default_checksums_src;
     }
-
 }
 
 open (my $checksums_fh, '<', $checksums_file) or die "Unable to read checksum file: $checksums_file - $!";
@@ -92,6 +96,7 @@ if ($about_flag) {
         print "Configured with:\n";
         print "- debug: ".$config->[0]->{debug}."\n" if $config->[0]->{debug};
         print "- verbose: ".$config->[0]->{verbose}."\n" if $config->[0]->{verbose};
+        print "- color: ".$config->[0]->{color}."\n" if $config->[0]->{color};
         print "\n";
     }
     print "Using data source located at: $checksums_file\n\n";
@@ -104,6 +109,8 @@ if ($about_flag) {
     print "--silent\n"                   if $silent_flag;
     print "--nochecksums\n"              if $nochecksums_flag;
     print "--checksums $checksums_src\n" if $checksums_src;
+    print "--nocolor\n"                  if $nocolor_flag;
+    print "--color\n"                    if $color_flag;
     print "--about\n"                    if $about_flag;
     print "\n";
 
@@ -125,6 +132,8 @@ if ($help_flag) {
     print "--silent: suppress all output and rely on return value\n";
     print "--nochecksums: ignore \$HOME/.config/.yak/checksums.json and use local .yaksums\n";
     print "--checksums <file>: specify alternative to \$HOME/.config/.yak/checksums.json\n";
+    print "--nocolor: disable colorized output\n";
+    print "--color: enable colorized output\n";
     print "--about: emit configuration and invocation description\n";
     print "\n";
 
@@ -163,13 +172,49 @@ sub _wanted {
         my $file_checksum = sha256_file_hex($file);
 
         if ($file_checksum eq $checksum) {
-            print STDERR  GREEN, "👍🏻$File::Find::name\n", RESET unless $silent_flag;
+            _print_success($color, $File::Find::name) unless $silent_flag;
         } else {
-            print STDERR RED, "❗️$File::Find::name\n", RESET  unless $silent_flag;
+            _print_failure($color, $File::Find::name)  unless $silent_flag;
             $rv = FAILURE;
         }
     } elsif (-f $file and $verbose) {
-        print STDERR FAINT, "  $File::Find::name skipped\n", RESET  unless $silent_flag;
+        _print_skip($color, $File::Find::name) unless $silent_flag;
+    }
+}
+
+sub _print_success {
+    my ($color, $filename, $silent_flag) = @_;
+
+    unless ($silent_flag) {
+        if ($color) {
+            print STDERR  GREEN, "👍🏻$filename\n", RESET;
+        } else {
+            print STDERR "👍🏻$File::Find::name\n";
+        }
+    }
+}
+
+sub _print_failure {
+    my ($color, $filename, $silent_flag) = @_;
+
+    unless ($silent_flag) {
+        if ($color) {
+            print STDERR RED, "❗️filename\n", RESET;
+        } else {
+            print STDERR "❗️filename\n";
+        }
+    }
+}
+
+sub _print_skip {
+    my ($color, $filename, $silent_flag) = @_;
+
+    unless ($silent_flag) {
+        if ($color) {
+            print STDERR FAINT, "  $filename skipped\n", RESET;
+        } else {
+            print STDERR "  $filename skipped\n";
+        }
     }
 }
 
@@ -191,6 +236,30 @@ sub _set_debug {
     }
 
     return $debug_flag || _is_debug_config_true($config) || FALSE;
+}
+
+sub _set_color {
+    my ($color_flag, $nocolor_flag, $config) = @_;
+
+    if ($nocolor_flag) {
+        return FALSE;
+    }
+
+    if ($color_flag) {
+        return TRUE;
+    }
+
+    return _is_color_config_false($config)?FALSE:TRUE;
+}
+
+sub _is_color_config_false {
+    my $config = shift;
+
+    if ($config and $config->[0]->{color}) {
+        return $config->[0]->{color} eq 'false'?TRUE:FALSE;
+    } else {
+        return FALSE;
+    }
 }
 
 sub _is_debug_config_true {
@@ -300,6 +369,10 @@ C<yak> takes the following command line arguments:
 
 =item * C<--checksums file>, reads alternative checksums file instead of default, see L</DATA_SOURCE>
 
+=item * C<--color>, enables colorized output, enabled by default or can be configured, see L</CONFIGURATION>
+
+=item * C<--nocolor>, disables colorized output, even if confgured or provided as C<--color>, see above
+
 =item * C<--about>, emits output on configuration and invocation and terminates with success
 
 =item * C<--help>, emits help message listing all available options
@@ -328,9 +401,11 @@ C<yak> can be configured using the following paramters:
 
 =over
 
-=item * C<verbose>, which enables more verbose output
+=item * C<verbose>, enabling (C<true>) or disabling (C<false>) more verbose output
 
-=item * C<debug>, which enables debug output
+=item * C<debug>, enabling (C<true>) or disabling (C<false>) debug output
+
+=item * C<color>, enabling (C<true>) or disabling (C<false>) colorized output
 
 =back
 


### PR DESCRIPTION
  - can be configured in: $HOME/.config/yak/config.yaml
  - can be used to override default value of enabled

- Added command line argument --color
  - can be used to override color configuration specified in: $HOME/.config/yak/config.yaml

- Added command line argument --nocolor
  - overriding default value of enabled
  - can be used to override color configuration specified in: $HOME/.config/yak/config.yaml
  - overriding --color command line argument

Closes issue #19 