### PR TITLE
Addressed issue 21 adding capability for custom emojis in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG for `yak`
 
+## 0.9.0 2020-11-22 Milestone release, implementing support for custom emojis
+
+- Added configuration option `success_emoji`
+  - can be configured in: `$HOME/.config/yak/config.yaml`
+  - can be used to override default emoji for successful checks
+
+- Added configuration option `failure_emoji`
+  - can be configured in: `$HOME/.config/yak/config.yaml`
+  - can be used to override default emoji for failing checks
+
+- Added configuration option `skip_emoji`
+  - can be configured in: `$HOME/.config/yak/config.yaml`
+  - can be used to override default emoji for skipped checks
+
 ## 0.8.0 2020-11-21 Milestone release, implementing emoji output control
 
 - Added configuration option `emoji`

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ This JSON file should be created as `$HOME/.config/yak/checksums.json`.
 `yak` takes the following command line arguments:
 
 - `--verbose`, enables more verbose output, can be configured see ["CONFIGURATION"](#configuration)
-- `--silent`, disables output and you have to rely on the return value see ["RETURN\_VALUES"](#return_values) below.
+- `--silent`, disables output and you have to rely on the return value see ["RETURN VALUES"](#return-values) below.
 - `--debug`, enables debug output. can be configured see ["CONFIGURATION"](#configuration)
 - `--nodebug`, disables debug output even if confgured or provided as `--debug`, see above
 - `--config file`, reads alternative configuration file instead of default, see ["CONFIGURATION"](#configuration)
 - `--noconfig`, disables reading of the configuration file, (see ["CONFIGURATION"](#configuration)) and you have to rely on the command line arguments
-- `--nochecksums`, disables reading of the global checksums file, see ["DATA\_SOURCE"](#data_source)
-- `--checksums file`, reads alternative checksums file instead of default, see ["DATA\_SOURCE"](#data_source)
+- `--nochecksums`, disables reading of the global checksums file, see ["DATA SOURCE"](#data-source)
+- `--checksums file`, reads alternative checksums file instead of default, see ["DATA SOURCE"](#data-source)
 - `--color`, enables colorized output, enabled by default or can be configured, see ["CONFIGURATION"](#configuration)
 - `--nocolor`, disables colorized output, even if confgured or provided as `--color`, see above
 - `--emoji`, enables emojis in output, enabled by default or can be configured, see ["CONFIGURATION"](#configuration)
@@ -88,6 +88,9 @@ Note that `--about` return as success with out processing any data apart from re
 - `debug`, enabling (`true`) or disabling (`false`) debug output
 - `color`, enabling (`true`) or disabling (`false`) colorized output
 - `emoji`, enabling (`true`) or disabling (`false`) colorized output
+- `success_emoji`
+- `failure_emoji`
+- `skip_emoji`
 
 Configuration can be overridden by command line arguments, see ["INVOCATION"](#invocation).
 
@@ -97,6 +100,9 @@ This YAML file should be created as `$HOME/.config/yak/config.yml`.
 
     verbose: false
     debug: false
+    skip_emoji: ✖️
+    failure_emoji: ❌
+    success_emoji: ✅
 
 # DATA SOURCE
 

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -3,4 +3,4 @@ ignore_dirs:
 - local
 verbose: false
 color: false
-emoji: false
+skip_emoji: ✖️

--- a/yak
+++ b/yak
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use v5.10; # say
 
+use utf8;
 use JSON; # from_json
 use YAML::Tiny;
 use Crypt::Digest::SHA256 qw(sha256_file_hex); # Provided by CryptX
@@ -16,6 +17,9 @@ use English; # $PROGRAM_NAME
 use Getopt::Long; # GetOptions
 use Cwd; # getcwd
 
+binmode STDOUT, ":utf8";
+binmode STDERR, ":utf8";
+
 use constant FALSE   => 0;
 use constant TRUE    => 1;
 use constant SUCCESS => 0;
@@ -23,8 +27,11 @@ use constant FAILURE => 1;
 
 our $VERSION = '1.0.0';
 
-my $default_checksums_src  = "$HOME/.config/yak/checksums.json";
-my $default_config_file    = "$HOME/.config/yak/config.yml";
+my $default_checksums_src = "$HOME/.config/yak/checksums.json";
+my $default_config_file   = "$HOME/.config/yak/config.yml";
+my $success_emoji         = '👍🏻';
+my $failure_emoji         = '❗️';
+my $skip_emoji            = '  ';
 
 my $debug_flag       = FALSE;
 my $nodebug_flag     = FALSE;
@@ -74,6 +81,16 @@ my $verbose = _set_verbose($verbosity_flag, $silent_flag, $config);
 my $debug = _set_debug($debug_flag, $nodebug_flag, $config);
 my $color = _set_color($color_flag, $nocolor_flag, $config);
 my $emoji = _set_emoji($emoji_flag, $noemoji_flag, $config);
+
+if (not $emoji) {
+    $success_emoji = '';
+    $failure_emoji = '';
+    $skip_emoji    = '';
+} else {
+    $success_emoji = _set_success_emoji($success_emoji, $config);
+    $failure_emoji = _set_failure_emoji($failure_emoji, $config);
+    $skip_emoji    = _set_skip_emoji($skip_emoji, $config);
+}
 
 # Reading the checksum data
 my $checksums_file = '';
@@ -182,29 +199,42 @@ sub _wanted {
         my $file_checksum = sha256_file_hex($file);
 
         if ($file_checksum eq $checksum) {
-            _print_success($color, $emoji, $File::Find::name) unless $silent_flag;
+            _print_success($color, $success_emoji, $File::Find::name) unless $silent_flag;
         } else {
-            _print_failure($color, $emoji, $File::Find::name)  unless $silent_flag;
+            _print_failure($color, $failure_emoji, $File::Find::name)  unless $silent_flag;
             $rv = FAILURE;
         }
     } elsif (-f $file and $verbose) {
-        _print_skip($color, $emoji, $File::Find::name) unless $silent_flag;
+        _print_skip($color, $skip_emoji, $File::Find::name) unless $silent_flag;
     }
+}
+
+sub _set_success_emoji {
+    my ($success_emoji, $config) = @_;
+    
+    return $config->[0]->{success_emoji} || $success_emoji;
+}
+
+sub _set_failure_emoji {
+    my ($failure_emoji, $config) = @_;
+    
+    return $config->[0]->{failure_emoji} || $failure_emoji;
+}
+
+sub _set_skip_emoji {
+    my ($skip_emoji, $config) = @_;
+    
+    return $config->[0]->{skip_emoji} || $skip_emoji;
 }
 
 sub _print_success {
     my ($color, $emoji, $filename, $silent_flag) = @_;
 
-    my $success_emoji = '👍🏻';
-    if (not $emoji) {
-        $success_emoji = '';
-    }
-
     unless ($silent_flag) {
         if ($color) {
-            say GREEN, $success_emoji . $filename . RESET;
+            say GREEN, $emoji . $filename . RESET;
         } else {
-            say $success_emoji . $filename;
+            say $emoji . $filename;
         }
     }
 }
@@ -212,16 +242,11 @@ sub _print_success {
 sub _print_failure {
     my ($color, $emoji, $filename, $silent_flag) = @_;
 
-    my $failure_emoji = '❗️';
-    if (not $emoji) {
-        $failure_emoji = '';
-    }
-
     unless ($silent_flag) {
         if ($color) {
-            say  RED, $failure_emoji . $filename . RESET;
+            say RED, $emoji . $filename . RESET;
         } else {
-            say $failure_emoji . $filename;
+            say $emoji . $filename;
         }
     }
 }
@@ -229,16 +254,11 @@ sub _print_failure {
 sub _print_skip {
     my ($color, $emoji, $filename, $silent_flag) = @_;
 
-    my $skip_emoji = '  ';
-    if (not $emoji) {
-        $skip_emoji = '';
-    }
-
     unless ($silent_flag) {
         if ($color) {
-            say FAINT, $skip_emoji . "$filename skipped", RESET;
+            say FAINT, $emoji . "$filename skipped", RESET;
         } else {
-            say $skip_emoji, "$filename skipped";
+            say $emoji, "$filename skipped";
         }
     }
 }

--- a/yak.pod
+++ b/yak.pod
@@ -71,7 +71,7 @@ C<yak> takes the following command line arguments:
 
 =item * C<--verbose>, enables more verbose output, can be configured see L</CONFIGURATION>
 
-=item * C<--silent>, disables output and you have to rely on the return value see L</RETURN_VALUES> below.
+=item * C<--silent>, disables output and you have to rely on the return value see L</RETURN VALUES> below.
 
 =item * C<--debug>, enables debug output. can be configured see L</CONFIGURATION>
 
@@ -81,9 +81,9 @@ C<yak> takes the following command line arguments:
 
 =item * C<--noconfig>, disables reading of the configuration file, (see L</CONFIGURATION>) and you have to rely on the command line arguments
 
-=item * C<--nochecksums>, disables reading of the global checksums file, see L</DATA_SOURCE>
+=item * C<--nochecksums>, disables reading of the global checksums file, see L</DATA SOURCE>
 
-=item * C<--checksums file>, reads alternative checksums file instead of default, see L</DATA_SOURCE>
+=item * C<--checksums file>, reads alternative checksums file instead of default, see L</DATA SOURCE>
 
 =item * C<--color>, enables colorized output, enabled by default or can be configured, see L</CONFIGURATION>
 
@@ -145,6 +145,9 @@ This YAML file should be created as C<$HOME/.config/yak/config.yml>.
 
     verbose: false
     debug: false
+    skip_emoji: ✖️
+    failure_emoji: ❌
+    success_emoji: ✅
 
 =head1 DATA SOURCE
 

--- a/yak.pod
+++ b/yak.pod
@@ -129,6 +129,12 @@ C<yak> can be configured using the following paramters:
 
 =item * C<emoji>, enabling (C<true>) or disabling (C<false>) colorized output
 
+=item * C<success_emoji>
+
+=item * C<failure_emoji>
+
+=item * C<skip_emoji>
+
 =back
 
 Configuration can be overridden by command line arguments, see L</INVOCATION>.


### PR DESCRIPTION
- Added configuration option `success_emoji`
  - can be configured in: `$HOME/.config/yak/config.yaml`
  - can be used to override default emoji for successful checks

- Added configuration option `failure_emoji`
  - can be configured in: `$HOME/.config/yak/config.yaml`
  - can be used to override default emoji for failing checks

- Added configuration option `skip_emoji`
  - can be configured in: `$HOME/.config/yak/config.yaml`
  - can be used to override default emoji for skipped checks